### PR TITLE
Calculate a new sequence_id without (possible) default scope

### DIFF
--- a/lib/sequence_on/sequenced_on.rb
+++ b/lib/sequence_on/sequenced_on.rb
@@ -25,11 +25,13 @@ module SequenceOn
         self.class.connection.execute("LOCK TABLE #{self.class.table_name} IN EXCLUSIVE MODE") if postgresql?
         last_record = if self.persisted?
                         self.class.class_exec(self, &options[:lmd]).
+                          unscoped.
                           order("#{options[:column]} DESC").
                           where("NOT id = ?", self.id).
                           first
                       else
                         self.class.class_exec(self, &options[:lmd]).
+                          unscoped.
                           order("#{options[:column]} DESC").
                           first
                       end

--- a/lib/sequence_on/sequenced_on.rb
+++ b/lib/sequence_on/sequenced_on.rb
@@ -24,14 +24,16 @@ module SequenceOn
         options = self.class.sequence_options
         self.class.connection.execute("LOCK TABLE #{self.class.table_name} IN EXCLUSIVE MODE") if postgresql?
         last_record = if self.persisted?
-                        self.class.class_exec(self, &options[:lmd]).
-                          unscoped.
+                        self.class
+                          .unscoped
+                          .class_exec(self, &options[:lmd]).
                           order("#{options[:column]} DESC").
                           where("NOT id = ?", self.id).
                           first
                       else
-                        self.class.class_exec(self, &options[:lmd]).
-                          unscoped.
+                        self.class
+                          .unscoped
+                          .class_exec(self, &options[:lmd]).
                           order("#{options[:column]} DESC").
                           first
                       end


### PR DESCRIPTION
## Why?

If the application uses gems, like `paranoia`, there's a risk that deleted record won't be visible because of `default_scope` and duplicated sequences may be produced.

## Solution
Add `unscoped` to "see" all the records.